### PR TITLE
offer a build method that doesn't require libtool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ $(LIBSMILE): $(SLIBSMILE_OBJS)
 libsmile: $(LIBSMILE_OBJS)
 	$(AR) cru $(LIB_DIR)/libsmile.a $(LIBSMILE_OBJS)
 
-
 ###########
 # unsmile #
 ###########

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ all: $(UNSMILE) $(LIBSMILE)
 $(LIBSMILE): $(SLIBSMILE_OBJS)
 	$(LIBTOOL) --tag=CC --mode=link $(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SLIBSMILE_OBJS)
 
+.PHONY: libsmile
+libsmile: $(LIBSMILE_OBJS)
+	$(AR) cru $(LIB_DIR)/libsmile.a $(LIBSMILE_OBJS)
+
+
 ###########
 # unsmile #
 ###########


### PR DESCRIPTION
gcc only with `make libsmile`. no need for libtool.