### PR TITLE
allocate block workspace on stack instead of heap

### DIFF
--- a/lib/block.c
+++ b/lib/block.c
@@ -21,8 +21,9 @@
 int smile_decode_block(void *dst, int dstlen, void *src, int srclen)
 {
     s_stream stream;
-    stream.workspace = malloc(sizeof(struct decode_workspace));
-    smile_decode_init(&stream);
+    struct decode_workspace workspace;
+    stream.workspace = &workspace;
+    smile_decode_reset(&stream);
 
     stream.next_in = src;
     stream.avail_in = srclen;
@@ -30,10 +31,7 @@ int smile_decode_block(void *dst, int dstlen, void *src, int srclen)
     stream.next_out = dst;
     stream.avail_out = dstlen;
 
-    // Decode block
     int err = smile_decode(&stream);
-
-    free(stream.workspace);
 
     if (err == -1) {
       return -EIO;


### PR DESCRIPTION
For reasons that elude me, the workspace `malloc` is provably the cause of a memory leak, despite the call to `free` a few lines below (I'm assuming the code is doing something funky with all it's weird conditionals on uninitialised variables and GOTOs). So, we can just allocate it on the heap instead and that fixes the memory leak.